### PR TITLE
Using constructor instead of init method

### DIFF
--- a/src/Hqub.Lastfm/Scrobbling/NowplayingTrack.cs
+++ b/src/Hqub.Lastfm/Scrobbling/NowplayingTrack.cs
@@ -29,25 +29,19 @@ namespace Lastfm.Scrobbling
 		public string MBID {get; set;}
 		public int Number {get; set;}
 		
-		private void init()
+		private NowplayingTrack()
 		{
 			Duration = new TimeSpan();
 		}
 		
-		public NowplayingTrack(string artist, string title)
+		public NowplayingTrack(string artist, string title) : this()
 		{
-			// Set initial values
-			init();
-			
 			Artist = artist;
 			Title = title;
 		}
 		
-		public NowplayingTrack(string artist, string title, TimeSpan duration)
+		public NowplayingTrack(string artist, string title, TimeSpan duration) : this()
 		{
-			// Set initial values
-			init();
-			
 			Artist = artist;
 			Title = title;
 			Duration = duration;

--- a/src/Hqub.Lastfm/Scrobbling/NowplayingTrack.cs
+++ b/src/Hqub.Lastfm/Scrobbling/NowplayingTrack.cs
@@ -40,10 +40,8 @@ namespace Lastfm.Scrobbling
 			Title = title;
 		}
 		
-		public NowplayingTrack(string artist, string title, TimeSpan duration) : this()
+		public NowplayingTrack(string artist, string title, TimeSpan duration) : this(artist, title)
 		{
-			Artist = artist;
-			Title = title;
 			Duration = duration;
 		}
 	}


### PR DESCRIPTION
No need to create an init method, just use a default constructor.  Made it private, so users will need to use other overloads.

Just skimming around the code, not sure if you're doing this anywhere else, which I presume you might.
