### PR TITLE
Improve handling of unexpected error responses with HTTP status code 200

### DIFF
--- a/src/Hqub.Lastfm.Tests/ArtistTests.cs
+++ b/src/Hqub.Lastfm.Tests/ArtistTests.cs
@@ -49,6 +49,20 @@
         }
 
         [Test]
+        public void TestGetInfoByMbidWithError()
+        {
+            var mbid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+            var exception = Assert.ThrowsAsync<ServiceException>(async () =>
+            {
+                var artist = await client.Artist.GetInfoByMbidAsync(mbid);
+            });
+
+            Assert.That(exception.ErrorCode, Is.EqualTo(6));
+            Assert.That(exception.Message, Is.EqualTo("The artist you supplied could not be found"));
+        }
+
+        [Test]
         public async Task TestGetSimilar()
         {
             var artists = await client.Artist.GetSimilarAsync(data["artist"], 10);

--- a/src/Hqub.Lastfm.Tests/EmbeddedResourceCache.cs
+++ b/src/Hqub.Lastfm.Tests/EmbeddedResourceCache.cs
@@ -35,6 +35,8 @@
 
             var path = string.Format(PATH_TEMPLATE, match.Groups[1].Value.ToLower());
 
+            path = PrepareSpecialCases(path, request);
+
             try
             {
                 stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(path);
@@ -47,6 +49,16 @@
             }
 
             return Task.FromResult(true);
+        }
+
+        private string PrepareSpecialCases(string path, string request)
+        {
+            if (path.EndsWith("artist.getinfo.xml") && request.Contains("mbid="))
+            {
+                return path.Replace("artist.getinfo.xml", "artist.getinfo.mbid.xml");
+            }
+
+            return path;
         }
     }
 }

--- a/src/Hqub.Lastfm.Tests/Hqub.Lastfm.Tests.csproj
+++ b/src/Hqub.Lastfm.Tests/Hqub.Lastfm.Tests.csproj
@@ -12,6 +12,7 @@
     <None Remove="data\xml\album.gettoptags.xml" />
     <None Remove="data\xml\album.search.xml" />
     <None Remove="data\xml\artist.getcorrection.xml" />
+    <None Remove="data\xml\artist.getinfo.mbid.xml" />
     <None Remove="data\xml\artist.getinfo.xml" />
     <None Remove="data\xml\artist.getsimilar.xml" />
     <None Remove="data\xml\artist.gettags.xml" />
@@ -58,6 +59,7 @@
     <EmbeddedResource Include="data\xml\album.gettoptags.xml" />
     <EmbeddedResource Include="data\xml\album.search.xml" />
     <EmbeddedResource Include="data\xml\artist.getcorrection.xml" />
+    <EmbeddedResource Include="data\xml\artist.getinfo.mbid.xml" />
     <EmbeddedResource Include="data\xml\artist.getinfo.xml" />
     <EmbeddedResource Include="data\xml\artist.getsimilar.xml" />
     <EmbeddedResource Include="data\xml\artist.gettags.xml" />

--- a/src/Hqub.Lastfm.Tests/Hqub.Lastfm.Tests.csproj
+++ b/src/Hqub.Lastfm.Tests/Hqub.Lastfm.Tests.csproj
@@ -101,9 +101,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hqub.Lastfm.Tests/data/xml/artist.getinfo.mbid.xml
+++ b/src/Hqub.Lastfm.Tests/data/xml/artist.getinfo.mbid.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<lfm status="failed"><error code="6">The artist you supplied could not be found</error>
+</lfm>

--- a/src/Hqub.Lastfm/Hqub.Lastfm.csproj
+++ b/src/Hqub.Lastfm/Hqub.Lastfm.csproj
@@ -8,12 +8,12 @@
     <Description>Implementation of the Last.fm API.</Description>
     <Product>Hqub.Lastfm</Product>
     <Company>h-qub.ru</Company>
-    <Copyright>Copyright h-qub.ru © 2014-2024</Copyright>
+    <Copyright>Copyright h-qub.ru © 2014-2025</Copyright>
     <Authors>Boris Glebov, Christian Woltering</Authors>
-    <AssemblyVersion>2.4.0.0</AssemblyVersion>
-    <FileVersion>2.4.0.0</FileVersion>
+    <AssemblyVersion>2.5.0.0</AssemblyVersion>
+    <FileVersion>2.5.0.0</FileVersion>
     <PackageTags>music lastfm last.fm scrobble scrobbler scrobbling</PackageTags>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <AssemblyName>Hqub.Lastfm</AssemblyName>
     <RootNamespace>Hqub.Lastfm</RootNamespace>
     <PackageIconUrl>https://cdn4.iconfinder.com/data/icons/black-icon-social-media/128/0993-lastfm.png</PackageIconUrl>

--- a/src/Hqub.Lastfm/ResponseParser.cs
+++ b/src/Hqub.Lastfm/ResponseParser.cs
@@ -135,6 +135,32 @@ namespace Hqub.Lastfm
             return info;
         }
 
+        internal bool TryParseResponseError(XDocument doc, out string message, out int code)
+        {
+            code = 0;
+            message = null;
+
+            var e = doc.Descendants("lfm").FirstOrDefault();
+
+            string status = e.HasAttributes ? e.Attribute("status").Value : string.Empty;
+
+            if (status == "failed")
+            {
+                var error = e.Element("error");
+
+                if (error != null)
+                {
+                    message = error.Value;
+
+                    int.TryParse(error.Attribute("code").Value, out code);
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         internal PageInfo ParsePageInfo(XElement node)
         {
             var info = new PageInfo();

--- a/src/Hqub.Lastfm/ResponseParser.cs
+++ b/src/Hqub.Lastfm/ResponseParser.cs
@@ -142,6 +142,8 @@ namespace Hqub.Lastfm
 
             var e = doc.Descendants("lfm").FirstOrDefault();
 
+            if (e == null) return false;
+
             string status = e.HasAttributes ? e.Attribute("status").Value : string.Empty;
 
             if (status == "failed")

--- a/src/Hqub.Lastfm/ServiceException.cs
+++ b/src/Hqub.Lastfm/ServiceException.cs
@@ -112,10 +112,10 @@ namespace Hqub.Lastfm
                 case 27:
                     return "Deprecated - This type of request is no longer supported.";
                 case 29:
-                    return "Rate Limit Exceded - Your IP has made too many requests in a short period, exceeding our API guidelines.";
+                    return "Rate Limit Exceeded - Your IP has made too many requests in a short period, exceeding our API guidelines.";
             }
 
-            return "This error does not exist.";
+            return "The provided error code does not exist.";
         }
     }
 }


### PR DESCRIPTION
The last.fm web service might return HTTP status code 200 but still return an error in its XML response. This resulted in an `NullReferenceException`. With changes in this PR the XML response is parsed and a `ServiceException` is thrown.

Closes #13 